### PR TITLE
Update to 1.16.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,11 +14,11 @@ apply plugin: 'maven'
 apply plugin: 'maven-publish'
 
 group 'xyz.brassgoggledcoders'
-version '1.15.2-' + getVersion()
+version '1.16.4-' + getVersion()
 archivesBaseName = "PatchouliProvider"
 
 minecraft {
-    mappings channel: "snapshot", version: "20200530-1.15.1"
+    mappings channel: 'snapshot', version: '20201028-1.16.3'
 }
 
 repositories {
@@ -29,8 +29,8 @@ repositories {
 }
 
 dependencies {
-    minecraft "net.minecraftforge:forge:1.15.2-31.0.14"
-    compile fg.deobf("vazkii.patchouli:Patchouli:1.15.2-1.2-29.147")
+    minecraft "net.minecraftforge:forge:1.16.4-35.1.13"
+    compile fg.deobf("vazkii.patchouli:Patchouli:1.16.2-47")
 }
 
 uploadArchives {
@@ -42,7 +42,7 @@ uploadArchives {
 }
 
 String getVersion() {
-    String version = "1.0.0"
+    String version = "1.0.2"
     String branch = project.hasProperty("branch") ? project.branch : ""
 
     if (branch != "") {

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ version '1.16.4-' + getVersion()
 archivesBaseName = "PatchouliProvider"
 
 minecraft {
-    mappings channel: 'snapshot', version: '20201028-1.16.3'
+    mappings channel: "snapshot", version: "20201028-1.16.3"
 }
 
 repositories {

--- a/src/main/java/xyz/brassgoggledcoders/patchouliprovider/BookBuilder.java
+++ b/src/main/java/xyz/brassgoggledcoders/patchouliprovider/BookBuilder.java
@@ -3,7 +3,7 @@ package xyz.brassgoggledcoders.patchouliprovider;
 import com.google.gson.JsonObject;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
-import vazkii.patchouli.api.PatchouliAPI;
+import vazkii.patchouli.common.util.ItemStackUtil;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -231,7 +231,7 @@ public class BookBuilder {
     }
 
     public BookBuilder setIndexIcon(ItemStack indexIcon) {
-        this.indexIcon = PatchouliAPI.instance.serializeItemStack(indexIcon);
+        this.indexIcon = ItemStackUtil.serializeStack(indexIcon);
         return this;
     }
 
@@ -256,7 +256,7 @@ public class BookBuilder {
     }
 
     public BookBuilder setCustomBookItem(ItemStack customBookItem) {
-        this.customBookItem = PatchouliAPI.instance.serializeItemStack(customBookItem);
+        this.customBookItem = ItemStackUtil.serializeStack(customBookItem);
         return this;
     }
 

--- a/src/main/java/xyz/brassgoggledcoders/patchouliprovider/CategoryBuilder.java
+++ b/src/main/java/xyz/brassgoggledcoders/patchouliprovider/CategoryBuilder.java
@@ -3,7 +3,7 @@ package xyz.brassgoggledcoders.patchouliprovider;
 import com.google.gson.JsonObject;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
-import vazkii.patchouli.api.PatchouliAPI;
+import vazkii.patchouli.common.util.ItemStackUtil;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -23,7 +23,7 @@ public class CategoryBuilder {
     private Boolean secret;
 
     protected CategoryBuilder(String id, String name, String description, ItemStack icon, BookBuilder bookBuilder) {
-        this(id, name, description, PatchouliAPI.instance.serializeItemStack(icon), bookBuilder);
+        this(id, name, description, ItemStackUtil.serializeStack(icon), bookBuilder);
     }
 
     protected CategoryBuilder(String id, String name, String description, String icon, BookBuilder bookBuilder) {

--- a/src/main/java/xyz/brassgoggledcoders/patchouliprovider/EntryBuilder.java
+++ b/src/main/java/xyz/brassgoggledcoders/patchouliprovider/EntryBuilder.java
@@ -4,7 +4,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
-import vazkii.patchouli.api.PatchouliAPI;
+import vazkii.patchouli.common.util.ItemStackUtil;
 import xyz.brassgoggledcoders.patchouliprovider.page.*;
 
 import java.util.ArrayList;
@@ -38,7 +38,7 @@ public class EntryBuilder {
     }
 
     protected EntryBuilder(String id, String name, ItemStack icon, CategoryBuilder parent) {
-        this(id, name, PatchouliAPI.instance.serializeItemStack(icon), parent);
+        this(id, name, ItemStackUtil.serializeStack(icon), parent);
     }
 
     JsonObject toJson() {
@@ -75,7 +75,7 @@ public class EntryBuilder {
         if (extraRecipeMappings != null) {
             JsonObject mappings = new JsonObject();
             for (Map.Entry<ItemStack, Integer> entry : extraRecipeMappings.entrySet()) {
-                mappings.addProperty(PatchouliAPI.instance.serializeItemStack(entry.getKey()), entry.getValue());
+                mappings.addProperty(ItemStackUtil.serializeStack(entry.getKey()), entry.getValue());
             }
             json.add("extra_recipe_mappings", mappings);
         }

--- a/src/main/java/xyz/brassgoggledcoders/patchouliprovider/page/SpotlightPageBuilder.java
+++ b/src/main/java/xyz/brassgoggledcoders/patchouliprovider/page/SpotlightPageBuilder.java
@@ -2,7 +2,7 @@ package xyz.brassgoggledcoders.patchouliprovider.page;
 
 import com.google.gson.JsonObject;
 import net.minecraft.item.ItemStack;
-import vazkii.patchouli.api.PatchouliAPI;
+import vazkii.patchouli.common.util.ItemStackUtil;
 import xyz.brassgoggledcoders.patchouliprovider.AbstractPageBuilder;
 import xyz.brassgoggledcoders.patchouliprovider.EntryBuilder;
 
@@ -14,7 +14,7 @@ public class SpotlightPageBuilder extends AbstractPageBuilder<SpotlightPageBuild
 
     public SpotlightPageBuilder(ItemStack stack, EntryBuilder parent) {
         super("spotlight", parent);
-        this.item = PatchouliAPI.instance.serializeItemStack(stack);
+        this.item = ItemStackUtil.serializeStack(stack);
     }
 
     @Override

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -1,6 +1,7 @@
 modLoader="javafml"
 loaderVersion="[31,)"
 issueTrackerURL="https://github.com/Brass-Goggled-Coders/PatchouliProvider/issues"
+license = "MIT"
 
 [[mods]]
     modId="patchouli_provider"


### PR DESCRIPTION
serializeitemStack seems to be removed from PatchouliAPI, but it's only calling serializeStack in ItemStackUtil.